### PR TITLE
Remove duplicate apostrophe

### DIFF
--- a/src/lib/field-directive.ts
+++ b/src/lib/field-directive.ts
@@ -164,7 +164,7 @@ const createRateLimitDirective = (
         const window = this.args.window || DEFAULT_WINDOW;
         const max = this.args.max || DEFAULT_MAX;
         const message =
-          this.args.message || `You are trying to access '${name}' too often'`;
+          this.args.message || `You are trying to access '${name}' too often`;
         const identityArgs =
           this.args.identityArgs || DEFAULT_FIELD_IDENTITY_ARGS;
         const fieldIdentity = getFieldIdentity(name, identityArgs, resolveArgs);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Typo fix

* **What is the current behavior?** (You can also link to an open issue here)

Error messages look like `You are trying to access 'addMessage' too often'` (notice the stray apostrophe at the end)


* **What is the new behavior (if this is a feature change)?**

Error messages look like `You are trying to access 'addMessage' too often` (notice no stray apostrophe at the end)

* **Other information**:
