### PR TITLE
[RFC] Add formatError method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ const GraphQLRateLimit = createRateLimitDirective({
    * you'd like to implement your own with your own database.
    */
   store: new MyCustomStore(),
+  /**
+   * Generate a custom error message. Note that the `message` passed in to the directive will be used 
+   * if its set.
+   */
+  formatError: ({ fieldName }) => {
+    return `Woah there, you are doing way too much ${fieldName}`
+  }
 });
 ```
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This patch introduces a new option to `createRateLimitDirective` called `formatError` (same as in graphql-js) that gets a bunch of parameters as arguments and can return a custom error message.

* **What is the current behavior?** (You can also link to an open issue here)

Specifying a custom message for every field because the default message is a bit too little verbose for me is pretty tedious.

* **What is the new behavior (if this is a feature change)?**

I can simply use the `formatError` method to get consistent error messages for all fields that are different from the default.

* **Other information**:

This patch was done by editing the file on GitHub.com and is completely untested. It might or might not work, but I figured there's no better way to kick off a discussion.

If this is something that you want to include in core I'm happy to work more on this PR, add tests, fix the formatting etc.