### PR TITLE
Export RateLimitError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ export * from './lib/field-directive';
 export * from './lib/store';
 export * from './lib/in-memory-store';
 export * from './lib/redis-store';
+export * from './lib/rate-limit-error';
 import { createRateLimitDirective } from './lib/field-directive';
 export default createRateLimitDirective;


### PR DESCRIPTION
Closes #5

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Exports RateLimitError

* **What is the current behavior?** (You can also link to an open issue here)

Cannot import RateLimitError without doing `import { RateLimitError } from 'graphql-rate-limit/build/main/lib/rate-limit-error'`

* **What is the new behavior (if this is a feature change)?**

Can `import { RateLimitError } from 'graphql-rate-limit'`
