### PR TITLE
[RFC] Add ability to rate limit by input length

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -14,7 +14,7 @@ const books = [
 ];
 
 const typeDefs = gql`
-	directive @rateLimit(message: String, identityArgs: [String], max: Int, window: String) on FIELD_DEFINITION
+	directive @rateLimit(message: String, identityArgs: [String], arrayLengthField: String, max: Int, window: String) on FIELD_DEFINITION
 
 	type Book {
 		title: String
@@ -27,6 +27,7 @@ const typeDefs = gql`
 
 	type Mutation {
 		createBook(title: String!, author: String!): Book @rateLimit(identityArgs: ["title"], max: 2, window: "10s")
+    deleteBooks(titles: [String]!): Book @rateLimit(identityArgs: ["title"], arrayLengthField: "titles", max: 4, window: "10s")
 	}
 `;
 
@@ -37,7 +38,10 @@ const resolvers = {
 	Mutation: {
 		createBook: (_, args) => {
 			books.push(args);
-			return args;
+      return args;
+    },
+    deleteBooks: () => {
+			return books[0];
 		}
 	}
 };

--- a/src/lib/field-directive.spec.ts
+++ b/src/lib/field-directive.spec.ts
@@ -95,3 +95,21 @@ test('validateResolve should return true for full stores', async t => {
     )
   );
 });
+
+test('validateResolve should add callCount timestamps', async t => {
+  const store = new InMemoryStore();
+  t.false(await validateResolve(store, { contextIdentity: '1', fieldIdentity: 'myField' }, {
+    callCount: 2,
+    max: 2,
+    windowMs: 1000
+  }));
+})
+
+test('validateResolve should return true when callCount is bigger than max', async t => {
+  const store = new InMemoryStore();
+  t.true(await validateResolve(store, { contextIdentity: '1', fieldIdentity: 'myField' }, {
+    callCount: 2,
+    max: 1,
+    windowMs: 1000
+  }));
+})

--- a/src/lib/field-directive.spec.ts
+++ b/src/lib/field-directive.spec.ts
@@ -98,18 +98,30 @@ test('validateResolve should return true for full stores', async t => {
 
 test('validateResolve should add callCount timestamps', async t => {
   const store = new InMemoryStore();
-  t.false(await validateResolve(store, { contextIdentity: '1', fieldIdentity: 'myField' }, {
-    callCount: 2,
-    max: 2,
-    windowMs: 1000
-  }));
-})
+  t.false(
+    await validateResolve(
+      store,
+      { contextIdentity: '1', fieldIdentity: 'myField' },
+      {
+        callCount: 2,
+        max: 2,
+        windowMs: 1000
+      }
+    )
+  );
+});
 
 test('validateResolve should return true when callCount is bigger than max', async t => {
   const store = new InMemoryStore();
-  t.true(await validateResolve(store, { contextIdentity: '1', fieldIdentity: 'myField' }, {
-    callCount: 2,
-    max: 1,
-    windowMs: 1000
-  }));
-})
+  t.true(
+    await validateResolve(
+      store,
+      { contextIdentity: '1', fieldIdentity: 'myField' },
+      {
+        callCount: 2,
+        max: 1,
+        windowMs: 1000
+      }
+    )
+  );
+});

--- a/src/lib/field-directive.ts
+++ b/src/lib/field-directive.ts
@@ -40,7 +40,7 @@ export interface GraphQLRateLimitDirectiveArgs {
   /**
    * Limit by the length of an input array
    */
-  readonly arrayLength?: string;
+  readonly arrayLengthField?: string;
 }
 
 export interface FormatErrorInput {
@@ -132,7 +132,9 @@ const validateResolve = async (
   const accessTimestamps = await store.getForIdentity(identity);
   // Create an array of callCount length, filled with the current timestamp
   const timestamp = Date.now();
-  const newTimestamps = [...new Array(options.callCount || 1)].map(() => timestamp);
+  const newTimestamps = [...new Array(options.callCount || 1)].map(
+    () => timestamp
+  );
   const filteredAccessTimestamps: ReadonlyArray<any> = [
     ...newTimestamps,
     ...accessTimestamps.filter(t => {
@@ -163,8 +165,8 @@ const createRateLimitDirective = (
     ): GraphQLDirective {
       return new GraphQLDirective({
         args: {
-          arrayLength: {
-            type: GraphQLString,
+          arrayLengthField: {
+            type: GraphQLString
           },
           identityArgs: {
             type: new GraphQLList(GraphQLString)
@@ -199,7 +201,8 @@ const createRateLimitDirective = (
         const identityArgs =
           this.args.identityArgs || DEFAULT_FIELD_IDENTITY_ARGS;
         const fieldIdentity = getFieldIdentity(name, identityArgs, resolveArgs);
-        const callCount = this.args.arrayLength ? (resolveArgs[this.args.arrayLength] ? (resolveArgs[this.args.arrayLength].length || 1) : 1) : 1;
+        const callCount =
+          get(resolveArgs, [this.args.arrayLengthField, 'length']) || 1;
         const message =
           this.args.message ||
           config.formatError({

--- a/src/lib/field-directive.ts
+++ b/src/lib/field-directive.ts
@@ -37,6 +37,10 @@ export interface GraphQLRateLimitDirectiveArgs {
    * Values to build into the key used to identify the resolve call.
    */
   readonly identityArgs?: ReadonlyArray<string>;
+  /**
+   * Limit by the length of an input array
+   */
+  readonly arrayLength?: string;
 }
 
 export interface FormatErrorInput {
@@ -126,10 +130,13 @@ const validateResolve = async (
   options: Options
 ) => {
   const accessTimestamps = await store.getForIdentity(identity);
+  // Create an array of callCount length, filled with the current timestamp
+  const timestamp = Date.now();
+  const newTimestamps = [...new Array(options.callCount || 1)].map(() => timestamp);
   const filteredAccessTimestamps: ReadonlyArray<any> = [
-    Date.now(),
-    ...accessTimestamps.filter(timestamp => {
-      return timestamp + options.windowMs > Date.now();
+    ...newTimestamps,
+    ...accessTimestamps.filter(t => {
+      return t + options.windowMs > Date.now();
     })
   ];
   await store.setForIdentity(
@@ -156,6 +163,9 @@ const createRateLimitDirective = (
     ): GraphQLDirective {
       return new GraphQLDirective({
         args: {
+          arrayLength: {
+            type: GraphQLString,
+          },
           identityArgs: {
             type: new GraphQLList(GraphQLString)
           },
@@ -189,6 +199,7 @@ const createRateLimitDirective = (
         const identityArgs =
           this.args.identityArgs || DEFAULT_FIELD_IDENTITY_ARGS;
         const fieldIdentity = getFieldIdentity(name, identityArgs, resolveArgs);
+        const callCount = this.args.arrayLength ? (resolveArgs[this.args.arrayLength] ? resolveArgs[this.args.arrayLength].length : 1) : 1;
         const message =
           this.args.message ||
           config.formatError({
@@ -202,7 +213,7 @@ const createRateLimitDirective = (
         const isExceedingMax = await validateResolve(
           config.store,
           { contextIdentity, fieldIdentity },
-          { windowMs, max }
+          { windowMs, max, callCount }
         );
 
         if (isExceedingMax) {

--- a/src/lib/field-directive.ts
+++ b/src/lib/field-directive.ts
@@ -199,7 +199,7 @@ const createRateLimitDirective = (
         const identityArgs =
           this.args.identityArgs || DEFAULT_FIELD_IDENTITY_ARGS;
         const fieldIdentity = getFieldIdentity(name, identityArgs, resolveArgs);
-        const callCount = this.args.arrayLength ? (resolveArgs[this.args.arrayLength] ? resolveArgs[this.args.arrayLength].length : 1) : 1;
+        const callCount = this.args.arrayLength ? (resolveArgs[this.args.arrayLength] ? (resolveArgs[this.args.arrayLength].length || 1) : 1) : 1;
         const message =
           this.args.message ||
           config.formatError({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,4 +6,5 @@ export interface Identity {
 export interface Options {
   readonly windowMs: number;
   readonly max: number;
+  readonly callCount?: number;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature


* **What is the current behavior?** (You can also link to an open issue here)

One cannot rate limit by input length

* **What is the new behavior (if this is a feature change)?**

One can limit by input length with the `arrayLength` argument to the
directive. Note that I am very unhappy with the `arrayLength` name, very
open to better suggestions!

* **Other information**:

See #24 for a longer explanation