### PR TITLE
Rate limit batch queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ Generate a custom error message. Note that the `message` passed in to the field 
 formatError: ({ fieldName }) => `Woah there, you are doing way too much ${fieldName}`
 ```
 
+#### `enableBatchRequestCache`
+
+This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility. 
+
+```js
+enableBatchRequestCache: false | true
+```
+
 ### Field Config
 
 #### `window`

--- a/src/lib/batch-request-cache.ts
+++ b/src/lib/batch-request-cache.ts
@@ -1,0 +1,28 @@
+export const getNoOpCache = () => ({
+  set: ({ newTimestamps }: { newTimestamps: number[] }) => newTimestamps
+});
+
+export const getWeakMapCache = () => {
+  const cache = new WeakMap();
+
+  return {
+    set: ({
+      context,
+      fieldIdentity,
+      newTimestamps
+    }: {
+      context: object;
+      fieldIdentity: string;
+      newTimestamps: number[];
+    }) => {
+      const currentCalls = cache.get(context) || {};
+
+      currentCalls[fieldIdentity] = [
+        ...(currentCalls[fieldIdentity] || []),
+        ...newTimestamps
+      ];
+      cache.set(context, currentCalls);
+      return currentCalls[fieldIdentity];
+    }
+  };
+};

--- a/src/lib/get-graphql-rate-limiter.spec.ts
+++ b/src/lib/get-graphql-rate-limiter.spec.ts
@@ -72,6 +72,28 @@ test('getGraphQLRateLimiter with an empty store passes, but second time fails', 
   );
 });
 
+test('getGraphQLRateLimiter should block a batch of rate limited fields in a single query', async t => {
+  const rateLimit = getGraphQLRateLimiter({
+    store: new InMemoryStore(),
+    identifyContext: context => context.id
+  });
+  const config = { max: 3, window: '1s' };
+  const field = {
+    parent: {},
+    args: {},
+    context: { id: '1' },
+    info: ({ fieldName: 'myField' } as any) as GraphQLResolveInfo
+  };
+  const requests = Array.from({ length: 5 })
+    .map(() => rateLimit(field, config))
+    .map(p => p.catch(e => e));
+
+  (await Promise.all(requests)).forEach((result, idx) => {
+    if (idx < 3) t.falsy(result);
+    else t.is(result, `You are trying to access 'myField' too often`);
+  });
+});
+
 test('getGraphQLRateLimiter timestamps should expire', async t => {
   const rateLimit = getGraphQLRateLimiter({
     store: new InMemoryStore(),

--- a/src/lib/get-graphql-rate-limiter.spec.ts
+++ b/src/lib/get-graphql-rate-limiter.spec.ts
@@ -75,7 +75,8 @@ test('getGraphQLRateLimiter with an empty store passes, but second time fails', 
 test('getGraphQLRateLimiter should block a batch of rate limited fields in a single query', async t => {
   const rateLimit = getGraphQLRateLimiter({
     store: new InMemoryStore(),
-    identifyContext: context => context.id
+    identifyContext: context => context.id,
+    enableBatchRequestCache: true
   });
   const config = { max: 3, window: '1s' };
   const field = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,4 +85,6 @@ export interface GraphQLRateLimitConfig {
    * Custom error messages.
    */
   readonly formatError?: (input: FormatErrorInput) => string;
+
+  readonly enableBatchRequestCache?: boolean;
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?  (Bug fix, feature, docs update, ...)
This PR modifies the timestamp store behavior to use a synchronous request/context cache first, before writing/reading to asynchronous storage.  This makes it more difficult to abuse race conditions with that store to circumvent rate limits. 

[This article](https://lab.wallarm.com/graphql-batching-attack/) describes a potential attack vector that this will hopefully mitigate some. 

#### What is the current behavior? (You can also link to an open issue here)
Imagine we define a rate limit like this:
```graphql
    type Query {
        test: String! @rateLimit(max: 1, window: "1s")
    }
```
And then query against the field with aliases like this: 
```graphql
    query {
        test
        otherTest: test
     }
```
This query returns successfully, resolving twice against the backend, and exceeding the rate limit for the field of once per second.

#### What is the new behavior (if this is a feature change)?
This happens because both fields read asynchronously from the store at the same time. The first one doesn't write that a 'call' has occurred before the second one reads. 

It'd be inefficient to synchronously resolve each fields cache read/write serially though, so instead I added a synchronous cache that we can share across a request. This solves this most obvious issue.  

After this PR, the example request above would error as it violates the rate limit. 


#### Other information:
I added this new behavior behind a flag, defaulting to false so that it can be merged in without needing a major bump.  