### PR TITLE
Disable Rate Limiting on Store Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,19 @@ Generate a custom error message. Note that the `message` passed in to the field 
 formatError: ({ fieldName }) => `Woah there, you are doing way too much ${fieldName}`
 ```
 
+#### `onStoreError`
+
+If your backing store (e.g. redis) throws an error, `graphql-rate-limit` will call this hook with the error. By default the error will be thrown, stopping/blocking the request.  If you supply a hook and don't rethrow the error in your handler, `graphql-rate-limit` will allow the request through, effectively disabling rate-limiting while your store is down.
+
+```js
+onStoreError: (exception) => {
+  // Do some logging or trigger an alert maybe?
+  logger.error(exception);
+
+  /* Not rethrowing the exception will allow the request through */
+}
+```
+
 #### `enableBatchRequestCache`
 
 This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility. 

--- a/src/lib/in-memory-store.spec.ts
+++ b/src/lib/in-memory-store.spec.ts
@@ -2,55 +2,64 @@
 import test from 'ava';
 import { InMemoryStore } from './in-memory-store';
 
-test('InMemoryStore sets correct timestamps', t => {
+test('InMemoryStore sets correct timestamps', async t => {
   const store = new InMemoryStore();
-  store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
+  await store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
     1,
     2,
     3
   ]);
   t.deepEqual(store.state, { foo: { bar: [1, 2, 3] } });
 
-  store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar2' }, [
-    4,
-    5
-  ]);
+  await store.setForIdentity(
+    { contextIdentity: 'foo', fieldIdentity: 'bar2' },
+    [4, 5]
+  );
   t.deepEqual(store.state, { foo: { bar: [1, 2, 3], bar2: [4, 5] } });
 
-  store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
+  await store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
     10,
     20
   ]);
   t.deepEqual(store.state, { foo: { bar: [10, 20], bar2: [4, 5] } });
 });
 
-test('InMemoryStore get correct timestamps', t => {
+test('InMemoryStore get correct timestamps', async t => {
   const store = new InMemoryStore();
-  store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
+  await store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
     1,
     2,
     3
   ]);
   t.deepEqual(
-    store.getForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }),
+    await store.getForIdentity({
+      contextIdentity: 'foo',
+      fieldIdentity: 'bar'
+    }),
     [1, 2, 3]
   );
 
-  store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar2' }, [
-    4,
-    5
-  ]);
+  await store.setForIdentity(
+    { contextIdentity: 'foo', fieldIdentity: 'bar2' },
+    [4, 5]
+  );
   t.deepEqual(
-    store.getForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar2' }),
+    await store.getForIdentity({
+      contextIdentity: 'foo',
+      fieldIdentity: 'bar2'
+    }),
     [4, 5]
   );
 
-  store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
+  await store.setForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }, [
     10,
     20
   ]);
   t.deepEqual(
-    store.getForIdentity({ contextIdentity: 'foo', fieldIdentity: 'bar' }),
+    await store.getForIdentity({
+      contextIdentity: 'foo',
+      fieldIdentity: 'bar'
+    }),
     [10, 20]
   );
 });

--- a/src/lib/in-memory-store.ts
+++ b/src/lib/in-memory-store.ts
@@ -14,10 +14,10 @@ class InMemoryStore implements Store {
   // tslint:disable-next-line readonly-keyword
   public state: StoreData = {};
 
-  public setForIdentity(
+  public async setForIdentity(
     identity: Identity,
     timestamps: readonly number[]
-  ): void {
+  ): Promise<void> {
     // tslint:disable-next-line no-object-mutation
     this.state = {
       ...(this.state || {}),
@@ -28,7 +28,7 @@ class InMemoryStore implements Store {
     };
   }
 
-  public getForIdentity(identity: Identity): readonly number[] {
+  public async getForIdentity(identity: Identity): Promise<readonly number[]> {
     const ctxState = this.state[identity.contextIdentity];
     return (ctxState && ctxState[identity.fieldIdentity]) || [];
   }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -11,7 +11,7 @@ abstract class Store {
     identity: Identity,
     timestamps: readonly number[],
     windowMs?: number
-  ): void | Promise<void>;
+  ): Promise<void>;
 
   /**
    * Gets an array of call timestamps for a given identity.
@@ -20,7 +20,7 @@ abstract class Store {
    */
   public abstract getForIdentity(
     identity: Identity
-  ): readonly number[] | Promise<readonly number[]>;
+  ): Promise<readonly number[]>;
 }
 
 export { Store };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,5 +86,11 @@ export interface GraphQLRateLimitConfig {
    */
   readonly formatError?: (input: FormatErrorInput) => string;
 
+  /**
+   * An optional error handler that will be called if checking a rate limit
+   * fails. (Normally due to failing to read/write from the store).
+   */
+  readonly onStoreError?: (exception: Error) => void;
+
   readonly enableBatchRequestCache?: boolean;
 }


### PR DESCRIPTION
This change is a little larger, no hard feelings if you don't think it fits in this repo.  

### What kind of change does this PR introduce?
This PR introduces a handler that gets called whenever the store fails to read or write, allowing users to choose what to do with this error.

### What is the current behavior?
Currently this error is thrown all the way up the stack, ultimately resulting in an INTERNAL_SERVER_ERROR and blocking the request completely (at least in my setup).  Meaning if your store goes down, no requests are going through. 

### What is the new behavior (if this is a feature change)?
Beyond just letting the user log these store errors effectively, if the users chooses not to rethrow the error, I've defaulted `graphql-rate-limit` to behave as if the store was empty.  Therefore all requests will be allowed through. This seems like a slightly more graceful experience for the end users.

### Other information:
I wanted to use .catch for this on the store operations, but since the InMemoryStore wasn't async, the code got messy really quickly.  I converted the inMemoryStore to be async, not sure if that change is too large or risky though. 🤔  