### PR TITLE
feat: add option to prevent registering the current validation

### DIFF
--- a/src/lib/get-graphql-rate-limiter.ts
+++ b/src/lib/get-graphql-rate-limiter.ts
@@ -112,6 +112,7 @@ const getGraphQLRateLimiter = (
       max,
       window,
       message,
+      readOnly,
     }: GraphQLRateLimitDirectiveArgs
   ): Promise<string | undefined> => {
     // Identify the user or client on the context
@@ -157,7 +158,9 @@ const getGraphQLRateLimiter = (
     ];
 
     // Save these access timestamps for future requests.
-    await store.setForIdentity(identity, filteredAccessTimestamps, windowMs);
+    if (!readOnly) {
+      await store.setForIdentity(identity, filteredAccessTimestamps, windowMs);
+    }
 
     // Field level custom message or a global formatting function
     const errorMessage =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,6 +50,11 @@ export interface GraphQLRateLimitDirectiveArgs {
    * Limit by the length of an input array
    */
   readonly arrayLengthField?: string;
+  /**
+   * Prevents registering the current request to the store.
+   * This can be useful for example when you only wanna rate limit on failed attempts.
+   */
+  readonly readOnly?: boolean;
 }
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Always registers rate limit calls as called.


* **What is the new behavior (if this is a feature change)?**
Has an option to not register the current call but read it only.


* **Other information**:
I call the rate limiter only on failed attempts (e.g. when the username or password is incorrect). Currently this is not possible as you can not check if the user is rate limited without logging the actual request as failed attempt. Adding a readOnly option allows you to call it on a succesive call and throw the error if a user was rate limited, thereby preventing brute force attacks.
