### PR TITLE
Create error function

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ Generate a custom error message. Note that the `message` passed in to the field 
 formatError: ({ fieldName }) => `Woah there, you are doing way too much ${fieldName}`
 ```
 
+
+#### `createError`
+
+Generate a custom error. By default, a [`RateLimitError`](https://github.com/teamplanes/graphql-rate-limit/blob/master/src/lib/rate-limit-error.ts) instance is created when a request is blocked. To return an instance of a different error class, you can return your own error using this field.
+
+```js
+createError: (message: string) => new ApolloError(message, '429');
+```
+
 #### `enableBatchRequestCache`
 
 This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility. 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <h1 align="center">💂‍♀️ GraphQL Rate Limit 💂‍♂️</h1>
 
 <p align="center">
@@ -16,6 +17,7 @@ A GraphQL Rate Limiter to add basic but granular rate limiting to your Queries o
 - 💼 Custom stores, use Redis, Postgres, Mongo... it defaults to in-memory
 - 💪 Written in TypeScript
 
+
 ## Install
 
 ```sh
@@ -30,38 +32,31 @@ yarn add graphql-rate-limit
 import { createRateLimitDirective } from 'graphql-rate-limit';
 
 // Step 1: get rate limit directive instance
-const rateLimitDirective = createRateLimitDirective({
-  identifyContext: (ctx) => ctx.id,
-});
+const rateLimitDirective = createRateLimitDirective({ identifyContext: (ctx) => ctx.id });
 
 const schema = makeExecutableSchema({
   schemaDirectives: {
-    rateLimit: rateLimitDirective,
+    rateLimit: rateLimitDirective
   },
   resolvers: {
     Query: {
-      getItems: () => [{ id: '1' }],
-    },
+      getItems: () => [{ id: '1' }]
+    }
   },
   typeDefs: gql`
     directive @rateLimit(
-      max: Int
-      window: String
-      message: String
-      identityArgs: [String]
+      max: Int,
+      window: String,
+      message: String,
+      identityArgs: [String],
       arrayLengthField: String
     ) on FIELD_DEFINITION
 
     type Query {
       # Step 2: Apply the rate limit instance to the field with config
-      getItems: [Item]
-        @rateLimit(
-          window: "1s"
-          max: 5
-          message: "You are doing that too often."
-        )
+      getItems: [Item] @rateLimit(window: "1s", max: 5, message: "You are doing that too often.")
     }
-  `,
+  `
 });
 ```
 
@@ -76,8 +71,8 @@ const rateLimitRule = createRateLimitRule({ identifyContext: (ctx) => ctx.id });
 const permissions = shield({
   Query: {
     // Step 2: Apply the rate limit rule instance to the field with config
-    getItems: rateLimitRule({ window: '1s', max: 5 }),
-  },
+    getItems: rateLimitRule({ window: "1s", max: 5 })
+  }
 });
 
 const schema = applyMiddleware(
@@ -89,12 +84,12 @@ const schema = applyMiddleware(
     `,
     resolvers: {
       Query: {
-        getItems: () => [{ id: '1' }],
-      },
-    },
+        getItems: () => [{ id: '1' }]
+      }
+    }
   }),
   permissions
-);
+)
 ```
 
 #### Option 3: Using the base rate limiter function
@@ -120,11 +115,11 @@ const schema = makeExecutableSchema({
           { max: 5, window: '10s' }
         );
         if (errorMessage) throw new Error(errorMessage);
-        return [{ id: '1' }];
-      },
-    },
-  },
-});
+        return [{ id: '1' }]
+      }
+    }
+  }
+})
 ```
 
 ## Configuration
@@ -142,15 +137,16 @@ And so... we have the same 'Instance Config' and 'Field Config' options which ev
 A required key and used to identify the user/client. The most likely cases are either using the context's request.ip, or the user ID on the context. A function that accepts the context and returns a string that is used to identify the user.
 
 ```js
-identifyContext: (ctx) => ctx.user.id;
+identifyContext: (ctx) => ctx.user.id
 ```
 
 #### `store`
 
 An optional key as it defaults to an InMemoryStore. See the implementation of InMemoryStore if you'd like to implement your own with your own database.
 
+
 ```js
-store: new MyCustomStore();
+store: new MyCustomStore()
 ```
 
 #### `formatError`
@@ -158,24 +154,15 @@ store: new MyCustomStore();
 Generate a custom error message. Note that the `message` passed in to the field config will be used if its set.
 
 ```js
-formatError: ({ fieldName }) =>
-  `Woah there, you are doing way too much ${fieldName}`;
-```
-
-#### `createError`
-
-Generate a custom error. By default, a [`RateLimitError`](https://github.com/teamplanes/graphql-rate-limit/blob/master/src/lib/rate-limit-error.ts) instance is created when a request is blocked. To return an instance of a different error class, you can return your own error using this field.
-
-```js
-createError: (message: string) => new ApolloError(message, '429');
+formatError: ({ fieldName }) => `Woah there, you are doing way too much ${fieldName}`
 ```
 
 #### `enableBatchRequestCache`
 
-This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility.
+This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility. 
 
 ```js
-enableBatchRequestCache: false | true;
+enableBatchRequestCache: false | true
 ```
 
 ### Field Config
@@ -200,6 +187,7 @@ A custom message per field. Note you can also use `formatError` to customise the
 
 Limit calls to the field, using the length of the array as the number of calls to the field.
 
+
 ## Redis Store Usage
 
 It is recommended to use a persistent store rather than the default InMemoryStore. GraphQLRateLimit currently supports Redis as an alternative. You'll need to install Redis in your project first.
@@ -208,10 +196,10 @@ It is recommended to use a persistent store rather than the default InMemoryStor
 import { createRateLimitDirective, RedisStore } from 'graphql-rate-limit';
 
 const GraphQLRateLimit = createRateLimitDirective({
-  identifyContext: (ctx) => ctx.user.id,
+  identifyContext: ctx => ctx.user.id,
   /**
    * Import the class from graphql-rate-limit and pass in an instance of redis client to the constructor
    */
-  store: new RedisStore(redis.createClient()),
+  store: new RedisStore(redis.createClient())
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <h1 align="center">💂‍♀️ GraphQL Rate Limit 💂‍♂️</h1>
 
 <p align="center">
@@ -17,7 +16,6 @@ A GraphQL Rate Limiter to add basic but granular rate limiting to your Queries o
 - 💼 Custom stores, use Redis, Postgres, Mongo... it defaults to in-memory
 - 💪 Written in TypeScript
 
-
 ## Install
 
 ```sh
@@ -32,31 +30,38 @@ yarn add graphql-rate-limit
 import { createRateLimitDirective } from 'graphql-rate-limit';
 
 // Step 1: get rate limit directive instance
-const rateLimitDirective = createRateLimitDirective({ identifyContext: (ctx) => ctx.id });
+const rateLimitDirective = createRateLimitDirective({
+  identifyContext: (ctx) => ctx.id,
+});
 
 const schema = makeExecutableSchema({
   schemaDirectives: {
-    rateLimit: rateLimitDirective
+    rateLimit: rateLimitDirective,
   },
   resolvers: {
     Query: {
-      getItems: () => [{ id: '1' }]
-    }
+      getItems: () => [{ id: '1' }],
+    },
   },
   typeDefs: gql`
     directive @rateLimit(
-      max: Int,
-      window: String,
-      message: String,
-      identityArgs: [String],
+      max: Int
+      window: String
+      message: String
+      identityArgs: [String]
       arrayLengthField: String
     ) on FIELD_DEFINITION
 
     type Query {
       # Step 2: Apply the rate limit instance to the field with config
-      getItems: [Item] @rateLimit(window: "1s", max: 5, message: "You are doing that too often.")
+      getItems: [Item]
+        @rateLimit(
+          window: "1s"
+          max: 5
+          message: "You are doing that too often."
+        )
     }
-  `
+  `,
 });
 ```
 
@@ -71,8 +76,8 @@ const rateLimitRule = createRateLimitRule({ identifyContext: (ctx) => ctx.id });
 const permissions = shield({
   Query: {
     // Step 2: Apply the rate limit rule instance to the field with config
-    getItems: rateLimitRule({ window: "1s", max: 5 })
-  }
+    getItems: rateLimitRule({ window: '1s', max: 5 }),
+  },
 });
 
 const schema = applyMiddleware(
@@ -84,12 +89,12 @@ const schema = applyMiddleware(
     `,
     resolvers: {
       Query: {
-        getItems: () => [{ id: '1' }]
-      }
-    }
+        getItems: () => [{ id: '1' }],
+      },
+    },
   }),
   permissions
-)
+);
 ```
 
 #### Option 3: Using the base rate limiter function
@@ -115,11 +120,11 @@ const schema = makeExecutableSchema({
           { max: 5, window: '10s' }
         );
         if (errorMessage) throw new Error(errorMessage);
-        return [{ id: '1' }]
-      }
-    }
-  }
-})
+        return [{ id: '1' }];
+      },
+    },
+  },
+});
 ```
 
 ## Configuration
@@ -137,16 +142,15 @@ And so... we have the same 'Instance Config' and 'Field Config' options which ev
 A required key and used to identify the user/client. The most likely cases are either using the context's request.ip, or the user ID on the context. A function that accepts the context and returns a string that is used to identify the user.
 
 ```js
-identifyContext: (ctx) => ctx.user.id
+identifyContext: (ctx) => ctx.user.id;
 ```
 
 #### `store`
 
 An optional key as it defaults to an InMemoryStore. See the implementation of InMemoryStore if you'd like to implement your own with your own database.
 
-
 ```js
-store: new MyCustomStore()
+store: new MyCustomStore();
 ```
 
 #### `formatError`
@@ -154,15 +158,24 @@ store: new MyCustomStore()
 Generate a custom error message. Note that the `message` passed in to the field config will be used if its set.
 
 ```js
-formatError: ({ fieldName }) => `Woah there, you are doing way too much ${fieldName}`
+formatError: ({ fieldName }) =>
+  `Woah there, you are doing way too much ${fieldName}`;
+```
+
+#### `createError`
+
+Generate a custom error. By default, a [`RateLimitError`](https://github.com/teamplanes/graphql-rate-limit/blob/master/src/lib/rate-limit-error.ts) instance is created when a request is blocked. To return an instance of a different error class, you can return your own error using this field.
+
+```js
+createError: (message: string) => new ApolloError(message, '429');
 ```
 
 #### `enableBatchRequestCache`
 
-This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility. 
+This enables a per-request synchronous cache to properly rate limit batch queries. Defaults to `false` to preserve backwards compatibility.
 
 ```js
-enableBatchRequestCache: false | true
+enableBatchRequestCache: false | true;
 ```
 
 ### Field Config
@@ -187,7 +200,6 @@ A custom message per field. Note you can also use `formatError` to customise the
 
 Limit calls to the field, using the length of the array as the number of calls to the field.
 
-
 ## Redis Store Usage
 
 It is recommended to use a persistent store rather than the default InMemoryStore. GraphQLRateLimit currently supports Redis as an alternative. You'll need to install Redis in your project first.
@@ -196,10 +208,10 @@ It is recommended to use a persistent store rather than the default InMemoryStor
 import { createRateLimitDirective, RedisStore } from 'graphql-rate-limit';
 
 const GraphQLRateLimit = createRateLimitDirective({
-  identifyContext: ctx => ctx.user.id,
+  identifyContext: (ctx) => ctx.user.id,
   /**
    * Import the class from graphql-rate-limit and pass in an instance of redis client to the constructor
    */
-  store: new RedisStore(redis.createClient())
+  store: new RedisStore(redis.createClient()),
 });
 ```

--- a/src/lib/field-directive.ts
+++ b/src/lib/field-directive.ts
@@ -66,7 +66,9 @@ const createRateLimitDirective = (
         );
 
         if (errorMessage) {
-          throw new RateLimitError(errorMessage);
+          throw customConfig.createError
+            ? customConfig.createError(errorMessage)
+            : new RateLimitError(errorMessage);
         }
 
         return resolve(parent, args, context, info);

--- a/src/lib/rate-limit-shield-rule.ts
+++ b/src/lib/rate-limit-shield-rule.ts
@@ -29,7 +29,14 @@ const createRateLimitRule = (
         },
         fieldConfig
       );
-      return errorMessage ? new RateLimitError(errorMessage) : true;
+
+      if (errorMessage) {
+        return config.createError
+          ? config.createError(errorMessage)
+          : new RateLimitError(errorMessage);
+      }
+
+      return true;
     });
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,6 +90,12 @@ export interface GraphQLRateLimitConfig {
    * Custom error messages.
    */
   readonly formatError?: (input: FormatErrorInput) => string;
+  /**
+   * Return an error.
+   *
+   * Defaults to new RateLimitError.
+   */
+  readonly createError?: (message: string) => Error;
 
   readonly enableBatchRequestCache?: boolean;
 }


### PR DESCRIPTION
## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature: add optional `createError` field to `GraphQLRateLimitConfig`

## Context
This PR was inspired by Issue #169. Currently, `graphql-rate-limit` returns and throws error messages in the form of `RateLimitError` instances. In some cases however, we may want to return the error message in the form of a different error class (ex. `ApolloError` or custom-defined error). This would allow users to expect errors that more closely match their existing error-handling system.

## Example Use-Case 1 (ApolloError)
Suppose that we want to return an `ApolloError` with error code `429` instead of a `RateLimitError` when requests exceed the rate limit. To accomplish this, we can include a `createError` function in the rate limit config:

```js
const rateLimitRule = createRateLimitRule({
    identifyContext: (ctx) => ctx.id,
    createError: (message) => new ApolloError(message, '429')
});
```

## Example Use-Case 2 (CustomError)
We can also return a custom error class as long as it extends `Error`.

```js
class CustomError extends Error {
    ...some custom error definition...
}

const rateLimitRule = createRateLimitRule({
    identifyContext: (ctx) => ctx.id,
    createError: (message) => new CustomError(message)
});
```

## Behavior with `formatError`
The `createError` config option is compatible with `formatError` since the `message` argument of the `createError` function is a formatted error message. For example, the following code will result in Apollo errors with the message: `"You are requesting field-name too much!"`

```js
const rateLimitRule = createRateLimitRule({
    identifyContext: (ctx) => ctx.id,
    formatError: ({ fieldName }) => `You are requesting ${fieldName} too much!`,
    createError: (message) => new ApolloError(message, '429')
});
```