### PR TITLE
Ignore counting rejected requests

### DIFF
--- a/src/lib/field-directive.ts
+++ b/src/lib/field-directive.ts
@@ -1,6 +1,7 @@
 import {
   defaultFieldResolver,
   DirectiveLocation,
+  GraphQLBoolean,
   GraphQLDirective,
   GraphQLField,
   GraphQLInt,
@@ -42,6 +43,9 @@ const createRateLimitDirective = (
           },
           window: {
             type: GraphQLString,
+          },
+          uncountRejected: {
+            type: GraphQLBoolean,
           },
         },
         locations: [DirectiveLocation.FIELD_DEFINITION],

--- a/src/lib/get-graphql-rate-limiter.ts
+++ b/src/lib/get-graphql-rate-limiter.ts
@@ -62,6 +62,7 @@ const getGraphQLRateLimiter = (
     max,
     window,
     message,
+    uncountRejected,
   }: GraphQLRateLimitDirectiveArgs
 ) => Promise<string | undefined>) => {
   // Default directive config
@@ -113,6 +114,7 @@ const getGraphQLRateLimiter = (
       window,
       message,
       readOnly,
+      uncountRejected,
     }: GraphQLRateLimitDirectiveArgs
   ): Promise<string | undefined> => {
     // Identify the user or client on the context
@@ -146,22 +148,27 @@ const getGraphQLRateLimiter = (
       newTimestamps,
     });
 
-    // Fetch timestamps from previous requests out of the store.
-    const accessTimestamps = await store.getForIdentity(identity);
+    // Fetch timestamps from previous requests out of the store
+    // and get all the timestamps that haven't expired
+    const filteredAccessTimestamps = (
+      await store.getForIdentity(identity)
+    ).filter((t) => {
+      return t + windowMs > Date.now();
+    });
 
-    // Get all the timestamps that haven't expired
-    const filteredAccessTimestamps: readonly any[] = [
-      ...batchedTimestamps,
-      ...accessTimestamps.filter((t) => {
-        return t + windowMs > Date.now();
-      }),
+    // Flag indicating requests limit reached
+    const limitReached =
+      filteredAccessTimestamps.length + batchedTimestamps.length > maxCalls;
+
+    // Confogure access timestamps to save according to uncountRejected setting
+    const timestampsToStore: readonly any[] = [
+      ...filteredAccessTimestamps,
+      ...(!uncountRejected || !limitReached ? batchedTimestamps : []),
     ];
 
-    const limitReached = filteredAccessTimestamps.length > maxCalls;
-
     // Save these access timestamps for future requests.
-    if (!readOnly && limitReached) {
-      await store.setForIdentity(identity, filteredAccessTimestamps, windowMs);
+    if (!readOnly) {
+      await store.setForIdentity(identity, timestampsToStore, windowMs);
     }
 
     // Field level custom message or a global formatting function

--- a/src/lib/get-graphql-rate-limiter.ts
+++ b/src/lib/get-graphql-rate-limiter.ts
@@ -157,8 +157,10 @@ const getGraphQLRateLimiter = (
       }),
     ];
 
+    const limitReached = filteredAccessTimestamps.length > maxCalls;
+
     // Save these access timestamps for future requests.
-    if (!readOnly) {
+    if (!readOnly && limitReached) {
       await store.setForIdentity(identity, filteredAccessTimestamps, windowMs);
     }
 
@@ -174,9 +176,7 @@ const getGraphQLRateLimiter = (
       });
 
     // Returns an error message or undefined if no error
-    return filteredAccessTimestamps.length > maxCalls
-      ? errorMessage
-      : undefined;
+    return limitReached ? errorMessage : undefined;
   };
 
   return rateLimiter;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,10 @@ export interface GraphQLRateLimitDirectiveArgs {
    * This can be useful for example when you only wanna rate limit on failed attempts.
    */
   readonly readOnly?: boolean;
+  /**
+   * Prevents rejected requests (due to limit reach) from being counted.
+   */
+  readonly uncountRejected?: boolean;
 }
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature - ability to not count request rejected by limit exceeding


* **What is the current behavior?** (You can also link to an open issue here)
Currently all request reaching the limiter are counted against the max quota


* **What is the new behavior (if this is a feature change)?**
An optional configuration attribute is introduced. If set true - requests blocked due to quota exceeding will not be counted

* **Other information**:
