### PR TITLE
graphql-middleware should actually be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "^7.6.0",
+    "graphql-middleware": "^6.0.4",
     "graphql-shield": "^7.5.0",
     "lodash.get": "^4.4.2",
     "ms": "^2.1.3"
@@ -48,7 +49,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
     "graphql": "^15.5.0",
-    "graphql-middleware": "^6.0.4",
     "nyc": "^15.1.0",
     "prettier": "^2.2.1",
     "redis-mock": "^0.56.3",


### PR DESCRIPTION
Otherwise, runtime errors about unknown dependencies from graphql-shield are thrown.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
Compiles fine, but throws errors around unknown dependency for 'graphql-middleware' when running jest tests.


* **What is the new behavior (if this is a feature change)?**
Compiles and runs fine during tests.


* **Other information**:
For context, I'm following `Option 3: using the base rate limiter function`.